### PR TITLE
emit "b" flag for named bss sections

### DIFF
--- a/gcc/config/i386/djgpp.c
+++ b/gcc/config/i386/djgpp.c
@@ -36,6 +36,8 @@ i386_djgpp_asm_named_section(const char *name, unsigned int flags,
     *f++ = 'w';
   if (flags & SECTION_CODE)
     *f++ = 'x';
+  if (flags & SECTION_BSS)
+    *f++ = 'b';
 
   /* LTO sections need 1-byte alignment to avoid confusing the
      zlib decompression algorithm with trailing zero pad bytes.  */


### PR DESCRIPTION
Hi, I suppose this is now the place to submit djgpp-specific gcc patches?  And I hope this is the correct branch to submit PRs to.  Note that I sent this patch to the gcc-patches list some time ago but it hasn't been included yet.  It would be nice if this patch could make it in gcc 10.1 (or 9.4).

For a long time now the djgpp linker scripts have linked `.bss.*` in `.data`:
```
    /* Ugly workaround to prevent entire .bss to have attribute CONTENT */
    /* for C++ executables. */
    *( .bss.*)
```
Yet `.gnu.linkonce.b.*` were still linked in `.bss`, which still ended up having the `CONTENTS` flag set.  All of this led to unnecessarily bloated executables.

Recently I sent a patch to binutils that makes the `"b"` flag on a `.section` directive clear the `CONTENTS` attribute, so now the easiest way to fix this for good is to make gcc emit this flag for named bss sections.
